### PR TITLE
feat: add envelope-http

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -45,5 +45,5 @@ python:
   methodArguments: infer-optional-args
   outputModelSuffix: output
   packageName: apideck-unify
-  responseFormat: flat
+  responseFormat: envelope-http
   templateVersion: v2

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Developer-friendly & type-safe Python SDK specifically catered to leverage *apid
 </div>
 
 
-<br /><br />
-> [!IMPORTANT]
-> This SDK is not yet ready for production use. To complete setup please follow the steps outlined in your [workspace](https://app.speakeasy.com/org/apideck-k2o/apideck). Delete this section before > publishing to a package manager.
-
 <!-- Start Summary [summary] -->
 ## Summary
 


### PR DESCRIPTION
This pull request includes changes to the configuration file for the Python SDK and updates to the README file. The most important changes include modifying the response format in the configuration file and removing a section from the README file that indicated the SDK was not ready for production use.

Configuration updates:

* [`.speakeasy/gen.yaml`](diffhunk://#diff-0f2bcc849ddce1a74ff8c03418150e851b1fb947992e6b14f76346a205806559L48-R48): Changed the `responseFormat` from `flat` to `envelope-http`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-L16): Removed the section indicating that the SDK is not yet ready for production use and instructions for setup.